### PR TITLE
Hide notebook name if not search_all

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 ## [Unreleased] [unreleased]
 ### Changed:
+- core: Do not show notebook name if only searching default notebook
 - docs: Converted documentation to Markdown syntax
 - core: LaunchSearch only makes sense if not search_all
 - core: LaunchSearch opens Jump To (Ctrl+J) and not Search (Ctrl+Shift+F)

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -115,7 +115,14 @@ class Provider(dbus.service.Object):
 			notebook_id, page_id = self._from_result_id(result_id)
 			path = page_id.split(":")
 			name = path[-1]
-			description = "(#%s) %s" % (notebook_id, "/".join(path[0:-1]))
+			if self.search_all:
+				template = "(#{notebook}) {path}"
+			else:
+				template = "{path}"
+			description = template.format(
+				notebook=notebook_id,
+				path="/".join(path[0:-1]),
+			)
 			meta = {
 				"id": result_id,
 				"name": name,


### PR DESCRIPTION
For readability, do not show the notebook name prefix "(#Notebook Name)" in the search results if the search only looks in the default notebook.

Closes dsboger/zimsearch#4.
