### PR TITLE
"New page" actions

### DIFF
--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -84,36 +84,42 @@ class Provider(dbus.service.Object):
 				in_signature='as', out_signature='as',
 				async_callbacks=('reply_handler', 'error_handler'))
 	def GetInitialResultSet(self, terms, reply_handler, error_handler):
+		"""Handles the initial search."""
 		notebook_terms, normal_terms = self._process_terms(terms)
 		search_notebooks = self._get_search_notebooks(notebook_terms)
 		result = []
 		if search_notebooks:
 			for search_notebook in search_notebooks:
 				result.extend(self._search_notebook(search_notebook, normal_terms))
+		self._process_results(result, terms)
 		reply_handler(result)
 	
 	@dbus.service.method(dbus_interface=SEARCH_IFACE,
 				in_signature='asas', out_signature='as',
 				async_callbacks=('reply_handler', 'error_handler'))
 	def GetSubsearchResultSet(self, prev_results, terms, reply_handler, error_handler):
+		"""Handles searches within sets of previously returned results."""
 		notebook_terms, normal_terms = self._process_terms(terms)
 		results = []
 		for result_id in prev_results:
-			notebook_id, page_id = self._from_result_id(result_id)
-			notebook_id_lower = notebook_id.lower()
-			if (not notebook_terms) or \
-					self._contains_any_term(notebook_id_lower, notebook_terms):
-				page_name_lower = page_id.split(':')[-1].lower()
-				if self._contains_all_terms(page_name_lower, normal_terms):
-					results.append(result_id)
+			notebook_id, page_id, create = self._from_result_id(result_id)
+			if create:
+				continue
+				# It will be added later, on the end, by _process_results().
+			if notebook_terms and not self._contains_all_terms(notebook_id, notebook_terms):
+				continue
+			if self._contains_all_terms(page_id, normal_terms):
+				results.append(result_id)
+		self._process_results(results, terms)
 		reply_handler(results)
 	
 	@dbus.service.method(dbus_interface=SEARCH_IFACE,
 						in_signature='as', out_signature='aa{sv}')
 	def GetResultMetas(self, identifiers):
+		"""Gets detailed metadata about identified search results."""
 		metas = []
 		for result_id in identifiers:
-			notebook_id, page_id = self._from_result_id(result_id)
+			notebook_id, page_id, create = self._from_result_id(result_id)
 			path = page_id.split(":")
 			name = path[-1]
 			if self.search_all:
@@ -124,10 +130,14 @@ class Provider(dbus.service.Object):
 				notebook=notebook_id,
 				path="/".join(path[0:-1]),
 			)
+			icon = "text-x-generic"
+			if create:
+				name = _(u"New page: “{}”").format(name)
+				icon = "text-x-generic-template"
 			meta = {
 				"id": result_id,
 				"name": name,
-				"gicon": "text-x-generic",
+				"gicon": icon,
 				"description": description
 			}
 			metas.append(meta)
@@ -136,40 +146,83 @@ class Provider(dbus.service.Object):
 	@dbus.service.method(dbus_interface=SEARCH_IFACE,
 						in_signature='sasu', out_signature='')
 	def ActivateResult(self, identifier, terms, timestamp):
-		notebook_id, page_id = self._from_result_id(identifier)
+		"""Handles the user choosing a search result from those offered."""
+		notebook_id, page_id, create = self._from_result_id(identifier)
 		server = self._get_server()
 		notebook = self._load_notebook(notebook_id)
 		gui = server.get_notebook(notebook)
 		gui.present(page=page_id)
+		# for the create case,
+		# could also do
+		# gui.new_page_from_text(" ".join(terms), open_page=True)
 	
 	@dbus.service.method(dbus_interface=SEARCH_IFACE,
 						in_signature='asu', out_signature='')
 	def LaunchSearch(self, terms, timestamp):
+		"""Handles the user choosing the app icon on the left of the results.
+
+		This is supposed to launch the application itself, with the search terms already typed in.
+
+		"""
 		server = self._get_server()
 		gui = server.get_notebook(self.notebook)
 		gui.present()
 		gui.show_search(" ".join(terms))
 		# FIXME: is it possible to make the GUI search all notebooks too?
 
+	def _process_results(self, results, terms):
+		"""Post-processing of the results set.
+
+		This adds extra "New page" results for all matching notebooks, or the default notebook if there were no notebook terms.
+
+		The new-page results are only appended if there are no preexising entries in the results.
+
+		"""
+
+		if len(results) > 0:
+			return
+
+		if not self.notebook:
+			return
+
+		notebook_terms, normal_terms = self._process_terms(terms)
+		page_id = " ".join(normal_terms)
+
+		if notebook_terms:
+			import zim.notebook
+			notebook_list = zim.notebook.get_notebook_list()
+			for notebook_info in notebook_list:
+				notebook_id = notebook_info.name
+				if self._contains_all_terms(notebook_id, notebook_terms):
+					result_id = self._to_result_id(notebook_id, page_id, create=True)
+					results.append(result_id)
+			return
+
+		notebook_id = self.notebook.name
+		result_id = self._to_result_id(notebook_id, page_id, create=True)
+		results.append(result_id)
+
 	def _process_terms(self, terms):
+		"""Pre-processing of search terms."""
 		notebook_terms = []
 		normal_terms = []
 		for term in terms:
 			if term.startswith("#"):
-				if not notebook_terms:
-					notebook_terms.append(term[1:].lower())
+				notebook_term = term[1:]
+				if len(notebook_term) > 0:
+					notebook_terms.append(notebook_term)
 			else:
-				normal_terms.append(term.lower())
+				normal_terms.append(term)
 		return notebook_terms, normal_terms
 	
 	def _get_search_notebooks(self, notebook_terms):
 		import zim.notebook
-		
+
 		search_notebooks_info = []
 		notebook_list = zim.notebook.get_notebook_list()
 		if notebook_terms:
 			for notebook_info in notebook_list:
-				if self._contains_any_term(notebook_info.name.lower(), notebook_terms): 
+				if self._contains_all_terms(notebook_info.name, notebook_terms):
 					search_notebooks_info.append(notebook_info)
 		elif self.search_all:
 			search_notebooks_info.extend(notebook_list)
@@ -181,8 +234,7 @@ class Provider(dbus.service.Object):
 
 	def _search_notebook(self, search_notebook, terms):
 		for page in search_notebook.index.walk():
-			page_name_lower = page.basename.lower()
-			if self._contains_all_terms(page_name_lower, terms):
+			if self._contains_all_terms(page.basename, terms):
 				yield self._to_result_id(search_notebook.name, page.name)
 	
 	def _load_notebook(self, notebook_id):
@@ -204,10 +256,11 @@ class Provider(dbus.service.Object):
 		zim.ipc.start_server_if_not_running()
 		return zim.ipc.ServerProxy()
 	
-	def _to_result_id(self, notebook_id, page_id):
+	def _to_result_id(self, notebook_id, page_id, create=False):
 		result_dict = {
 			"notebook": notebook_id,
 			"page": page_id,
+			"create": create,
 		}
 		return json.dumps(result_dict)
 	
@@ -216,16 +269,18 @@ class Provider(dbus.service.Object):
 		return (
 			result_dict.get("notebook", self.notebook.name),
 			result_dict.get("page", "New Page"),
+			result_dict.get("create", False),
 		)
 	
 	def _contains_all_terms(self, contents, terms):
 		for term in terms:
-			if not term in contents:
+			# Py3: use str(x), x.casefold()
+			if unicode(term).lower() not in unicode(contents).lower():
 				return False
 		return True
 	
 	def _contains_any_term(self, contents, terms):
 		for term in terms:
-			if term in contents:
+			if unicode(term).lower() in unicode(contents).lower():
 				return True
 		return False

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -5,6 +5,7 @@
 '''Zim plugin to display Zim pages in GNOME Shell search results.
 '''
 
+import json
 import logging
 
 logger = logging.getLogger('zim.plugins.gnomeshellsearch')
@@ -204,10 +205,18 @@ class Provider(dbus.service.Object):
 		return zim.ipc.ServerProxy()
 	
 	def _to_result_id(self, notebook_id, page_id):
-		return notebook_id + "#" + page_id
+		result_dict = {
+			"notebook": notebook_id,
+			"page": page_id,
+		}
+		return json.dumps(result_dict)
 	
 	def _from_result_id(self, result_id):
-		return result_id.split("#")
+		result_dict = json.loads(result_id)
+		return (
+			result_dict.get("notebook", self.notebook.name),
+			result_dict.get("page", "New Page"),
+		)
 	
 	def _contains_all_terms(self, contents, terms):
 		for term in terms:

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -144,11 +144,11 @@ class Provider(dbus.service.Object):
 	@dbus.service.method(dbus_interface=SEARCH_IFACE,
 						in_signature='asu', out_signature='')
 	def LaunchSearch(self, terms, timestamp):
-		if not self.search_all:
-			server = self._get_server()
-			gui = server.get_notebook(self.notebook)
-			gui.present()
-			gui.open_page()
+		server = self._get_server()
+		gui = server.get_notebook(self.notebook)
+		gui.present()
+		gui.show_search(" ".join(terms))
+		# FIXME: is it possible to make the GUI search all notebooks too?
 
 	def _process_terms(self, terms):
 		notebook_terms = []


### PR DESCRIPTION
These commits add a few nifty features to make the zimsearch experience a bit more like [nvPY](https://github.com/cpbotha/nvpy). Specifically:

* You can create new Zim pages from the GNOME search overlay.
  - When no existing page has matched, you see results like <samp>New Page: “Ode to Spam”</samp> instead.
  - They're given a distinctive icon to make it clear that this will make a new note.
  - It quickly becomes second nature to bash out something like <kbd>Meta</kbd> `Ode to Spam` <kbd>Return</kbd> if you want to make a new note on something.
  - This add-on search is sensitive to `#Notebook` search terms too.
* Clicking on the app icon next to the results now launches Zim's own search dialog.
  - This is currently limited to just the default notebook.