### PR TITLE
Ported for Python 3 and Newer Zim Versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,6 @@ import os
 import sys
 import textwrap
 
-
-# The launcher script doesn't strictly require Python 2, but the plugin
-# code does. Not that we install any modules just yet.
-
-if not ((2,) < sys.version_info < (3,)):
-    print("This program requires Python 2.", file=sys.stderr)
-    print("Please re-run with python2 (or pip2).", file=sys.stderr)
-    sys.exit(1)
-
-
 # Setuptools/distutils import compatability:
 
 try:
@@ -34,10 +24,10 @@ except:
 finally:
     from distutils.command.install_data import install_data as _install_data
 
-
 # Support classes:
 
-class install (_install):  # noqa: N801
+
+class install(_install):  # noqa: N801
     """Standard install command, extended for data & var substitution.
 
     Setuptools has a design flaw whereby data cannot be installed except
@@ -46,7 +36,6 @@ class install (_install):  # noqa: N801
     of "pip uninstall" however, because the alternatives are nasty.
 
     """
-
     def run(self):
         """Override, adding back in what "install_data" used to do."""
         _install.run(self)
@@ -56,7 +45,7 @@ class install (_install):  # noqa: N801
             install_data.run()
 
 
-class install_data (_install_data):  # noqa: N801
+class install_data(_install_data):  # noqa: N801
     """Standard install_data command, extended for variable substitution
 
     This recognises input filenames with ".in" filename extensions, and
@@ -85,15 +74,14 @@ class install_data (_install_data):  # noqa: N801
 
         """
         if not infile.endswith(".in"):
-            result = _install_data.copy_file(self, infile, outdir,
-                                             *args, **kwargs)
+            result = _install_data.copy_file(self, infile, outdir, *args,
+                                             **kwargs)
         else:
             out_basename = os.path.basename(infile)
             (out_basename, _) = os.path.splitext(out_basename)
             outfile = os.path.join(outdir, out_basename)
-            self.announce("expanding %s -> %s" % (infile, outfile),
-                          level=2)
-            self.announce("substs: %r" % (self.substs,), level=1)
+            self.announce("expanding %s -> %s" % (infile, outfile), level=2)
+            self.announce("substs: %r" % (self.substs, ), level=1)
             if not self.dry_run:
                 in_fp = open(infile, 'r')
                 if os.path.exists(outfile):
@@ -134,7 +122,7 @@ class install_data (_install_data):  # noqa: N801
 
 setup(
     name='zimsearch',
-    version='0.0.2a',  # SemVer, interfaces unstable [0.x] while Zim's are too.
+    version='0.0.2a1',  # SemVer, interfaces unstable [0.x] while Zim's are too.
     license="GPL-2.0+",
     description='GNOME integration for Zim 0.67+',
     url='https://github.com/achadwick/zimsearch',
@@ -149,12 +137,11 @@ setup(
     author_email='a.t.chadwick@gmail.com',
     scripts=["zim-gnomeshellsearch"],
     data_files=[
-        ('share/zim/plugins',
-            ["src/gnomeshellsearch.py"]),
+        ('share/zim/plugins', ["src/gnomeshellsearch.py"]),
         ('share/dbus-1/services',
-            ["data/zim.plugins.gnomeshellsearch.provider.service.in"]),
+         ["data/zim.plugins.gnomeshellsearch.provider.service.in"]),
         ('share/gnome-shell/search-providers',
-            ["data/zim.plugins.gnomeshellsearch.provider.ini.in"]),
+         ["data/zim.plugins.gnomeshellsearch.provider.ini.in"]),
     ],
     cmdclass={
         'install': install,
@@ -169,8 +156,10 @@ setup(
         "Intended Audience :: End Users/Desktop",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "Topic :: Desktop Environment",
         "Topic :: Utilities",
     ],
     include_package_data=True,
+    use_2to3=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ class install_data(_install_data):  # noqa: N801
 
 setup(
     name='zimsearch',
-    version='0.0.2a1',  # SemVer, interfaces unstable [0.x] while Zim's are too.
+    version='0.0.2-alpha.0',  # SemVer, interfaces unstable [0.x] while Zim's are too.
     license="GPL-2.0+",
     description='GNOME integration for Zim 0.67+',
     url='https://github.com/achadwick/zimsearch',

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -93,14 +93,14 @@ class Provider (dbus.service.Object):
         self.search_all = search_all
 
     def main(self):
-        from gi.repository import Gtk
+        from gi.repository import GLib
 
-        Gtk.main()
+        GLib.MainLoop().run()
 
     def quit(self):
-        from gi.repository import Gtk
+        from gi.repository import GLib
 
-        Gtk.main_quit()
+        GLib.MainLoop().quit()
 
     @dbus.service.method(dbus_interface=SEARCH_IFACE,
                          in_signature='as', out_signature='as',

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -3,6 +3,7 @@
 # Copyright 2014-2015 Davi da Silva Böger <dsboger@gmail.com>
 """Zim plugin to display Zim pages in GNOME Shell search results."""
 
+import os
 import json
 import logging
 import textwrap
@@ -34,11 +35,11 @@ class GnomeShellSearchPluginCommand (NotebookCommand):
             logger.error("No notebooks?")
             return
         notebook, _junk = zim.notebook.build_notebook(notebook_info)
-        config_manager = ConfigManager()
-        config_dict = config_manager.get_config_dict('preferences.conf')
+        config_manager = ConfigManager
+        config_dict = config_manager.preferences
         preferences = config_dict['GnomeShellSearch']
         preferences.setdefault('search_all', True)
-        Provider(notebook, preferences['search_all']).main()
+        Provider.main()
 
 
 class GnomeShellSearch (PluginClass):
@@ -64,8 +65,31 @@ class GnomeShellSearch (PluginClass):
         ),
     )
 
-    def __init__(self, config=None):
-        PluginClass.__init__(self, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        notebook = self.get_default_or_only_notebook()
+        logger.debug("{} notebook is set as default in shell search.".format(notebook))
+        if not Provider.run_flag:
+            Provider(notebook=notebook,search_all=self.preferences['search_all'])
+    
+    @staticmethod
+    def get_default_or_only_notebook():
+        """
+        Most of this method is copied from `zim.main.NotebookCommand.get_default_or_onlly_notebook`.
+        But this method return a notebook directly instead (just like `GnomeShellSearchPlugin.run` did).
+        """
+        from zim.notebook import get_notebook_list, resolve_notebook, build_notebook
+        notebooks = get_notebook_list()
+        uri = None
+        if notebooks.default:
+            uri = notebooks.default.uri
+        elif len(notebooks) == 1:
+            uri = notebooks[0].uri
+        else:
+            return None
+        notebook_info = resolve_notebook(uri, pwd=os.getcwd())  # The `pwd` is default value of `zim.main.Command.pwd`
+        result, _ = build_notebook(notebook_info)
+        return result
 
 
 # Dbus activation and search provider:
@@ -75,9 +99,20 @@ BUS_NAME = 'net.launchpad.zim.plugins.gnomeshellsearch.provider'
 OBJECT_PATH = '/net/launchpad/zim/plugins/gnomeshellsearch/provider'
 
 
-class Provider (dbus.service.Object):
+class Provider(dbus.service.Object):
+    """
+    The main search provider.  
+    To ensure that the provider does not started before, check `Provider.run_flag` before to construct the class.
+    For example:
+
+        if not Provider.run_flag:
+            Provider(...)
+    """
+    run_flag = False
 
     def __init__(self, notebook=None, search_all=True):
+        assert (not self.run_flag)  # make sure the Provider does not run twice or more in one application
+        self.run_flag = True
         import dbus.mainloop.glib
 
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
@@ -92,12 +127,14 @@ class Provider (dbus.service.Object):
         self.notebook_cache = {}
         self.search_all = search_all
 
-    def main(self):
+    @staticmethod
+    def main():
         from gi.repository import GLib
 
         GLib.MainLoop().run()
 
-    def quit(self):
+    @staticmethod
+    def quit():
         from gi.repository import GLib
 
         GLib.MainLoop().quit()

--- a/src/gnomeshellsearch.py
+++ b/src/gnomeshellsearch.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016-2017 Andrew Chadwick <a.t.chadwick@gmail.com>
 # Copyright 2014-2015 Davi da Silva Böger <dsboger@gmail.com>
-
 """Zim plugin to display Zim pages in GNOME Shell search results."""
 
 import json
@@ -18,7 +17,6 @@ from zim.search import Query
 
 logger = logging.getLogger(__name__)
 ZIM_COMMAND = "zim"
-
 
 # Zim plugin inegration:
 
@@ -95,14 +93,14 @@ class Provider (dbus.service.Object):
         self.search_all = search_all
 
     def main(self):
-        import gtk
+        from gi.repository import Gtk
 
-        gtk.main()
+        Gtk.main()
 
     def quit(self):
-        import gtk
+        from gi.repository import Gtk
 
-        gtk.main_quit()
+        Gtk.main_quit()
 
     @dbus.service.method(dbus_interface=SEARCH_IFACE,
                          in_signature='as', out_signature='as',

--- a/zim-gnomeshellsearch
+++ b/zim-gnomeshellsearch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # Launch Zim with the gnomeshellsearch plugin.
 
 import os


### PR DESCRIPTION
Finished works:
- code ported to python 3 by 2to3 (see `setup.py`)
- rewrite plug-in logic for newer Zim versions (see class `GnomeShellSearch`)

I have tested it on GNOME 3.36.4 with Zim 0.73.2.